### PR TITLE
Fix Frontend Swaps Error

### DIFF
--- a/src/components/cards/SwapCard/SwapButton/SwapButton.tsx
+++ b/src/components/cards/SwapCard/SwapButton/SwapButton.tsx
@@ -14,7 +14,7 @@ export const SwapButton = ({ error, onClick, isLoading }: SwapButtonProps) => {
 			size="lg"
 			variant="primary"
 			isLoading={isLoading}
-			onClick={isConnected ? onClick : open}
+			onClick={isConnected ? onClick : async () => { await open(); }}
 		>
 			{isConnected ? 'Begin Swap' : 'Connect Wallet'}
 		</Button>

--- a/src/components/cards/SwapCard/SwapInput/SwapInput.tsx
+++ b/src/components/cards/SwapCard/SwapInput/SwapInput.tsx
@@ -8,13 +8,21 @@ import { SwapIcon } from '../../../../assets/icons/SwapIcon'
 import { IconButton } from '../../../layout/buttons/IconButton/IconButton'
 import { FeeDetailsDropdown } from '../SwapDetails/FeeDetailsDropdown/FeeDetailsDropdown'
 import { Separator } from '../../../layout/Separator/Separator'
+import { getWalletClient } from '@wagmi/core'
+import { config } from '../../../../web3/wagmi'
 
 export const SwapInput = ({ swapState, swapDispatch }: SwapInputProps) => {
 	const handleSwapButtonClick = async () => {
-		await handleSwap({
-			swapState,
-			swapDispatch,
-		})
+		try {
+			const walletClient = await getWalletClient(config, { chainId: Number(swapState.from.chain.id) })
+			await handleSwap({
+				swapState,
+				swapDispatch,
+				walletClient,
+			})
+		} catch (error) {
+			console.error('Error initializing swap:', error)
+		}
 	}
 
 	const switchDirectionButton = (

--- a/src/components/cards/SwapCard/SwapProgress/SwapProgress.tsx
+++ b/src/components/cards/SwapCard/SwapProgress/SwapProgress.tsx
@@ -35,7 +35,6 @@ const chainsTwitterMap: Record<string, string> = {
 export const SwapProgress: FC<SwapProgressProps> = ({ swapState, handleGoBack }) => {
 	const [time, setTime] = useState(0)
 	const { to, from, steps, stage } = swapState
-
 	const isBridge = to.chain.id !== from.chain.id
 	const isFailed = stage === SwapCardStage.failed
 	const isSuccess = stage === SwapCardStage.success

--- a/src/components/cards/SwapCard/swapExecution/executeConceroRoute.ts
+++ b/src/components/cards/SwapCard/swapExecution/executeConceroRoute.ts
@@ -1,20 +1,24 @@
-import { type SwapAction, SwapCardStage, type SwapState } from '../swapReducer/types'
+import { StageType, type SwapAction, SwapCardStage, type SwapState } from '../swapReducer/types'
 import { type Dispatch } from 'react'
 import { type ExecutionConfigs, type ExecutionState } from '../../../../sdk/types/executeSettingsTypes'
 import { executeRoute } from '../../../../sdk/executeRoute/executeRoute'
 import { statusSwapMap } from './statusSwapMap'
 import { type RouteData } from '../../../../sdk/types/routeTypes'
-import { getWalletClient } from '@wagmi/core'
-import { config } from '../../../../web3/wagmi'
 import { trackEvent } from '../../../../hooks/useTracking'
 import { action, category } from '../../../../constants/tracking'
+import { type WalletClient } from 'viem'
 
-export async function executeConceroRoute(swapState: SwapState, swapDispatch: Dispatch<SwapAction>, route: RouteData) {
+interface ExecuteConceroRoute {
+	swapState: SwapState
+	swapDispatch: Dispatch<SwapAction>
+	route: RouteData
+	walletClient: WalletClient
+}
+
+export async function executeConceroRoute({ swapState, swapDispatch, route, walletClient }: ExecuteConceroRoute) {
 	swapDispatch({ type: 'SET_LOADING', payload: true })
 
 	try {
-		const walletClient = await getWalletClient(config, { chainId: Number(swapState.from.chain.id) })
-
 		const addExecutionListener = (state: ExecutionState) => {
 			statusSwapMap[state.stage](swapDispatch, state)
 		}
@@ -30,20 +34,24 @@ export async function executeConceroRoute(swapState: SwapState, swapDispatch: Di
 			data: { from: swapState.from, to: swapState.to },
 		})
 
-		console.log('USER BALANCE:', swapState.balance.amount.formatted)
 		await executeRoute(walletClient, route, executionConfig)
-	} catch (error) {
+	} catch (error: any) {
+		const errorMessage = error.message || 'Internal error'
+		const errorData = error.data || {}
+
 		swapDispatch({ type: 'SET_SWAP_STAGE', payload: SwapCardStage.failed })
 		swapDispatch({
 			type: 'SET_SWAP_STEPS',
-			payload: [{ title: 'Transaction failed', body: 'Internal error', status: 'error' }],
+			payload: [
+				{ title: 'Transaction failed', body: 'Internal error', status: 'error', type: StageType.warning },
+			],
 		})
 
 		trackEvent({
 			category: category.SwapCard,
 			action: action.FrontendSwapFailed,
 			label: 'fe_swap_failed',
-			data: { route, error },
+			data: { route, error: { message: errorMessage, data: errorData } },
 		})
 	}
 }

--- a/src/components/cards/SwapCard/swapExecution/handleSwap.ts
+++ b/src/components/cards/SwapCard/swapExecution/handleSwap.ts
@@ -3,13 +3,15 @@ import { type Dispatch } from 'react'
 import { type SwapAction, SwapCardStage, type SwapState } from '../swapReducer/types'
 import { executeConceroRoute } from './executeConceroRoute'
 import { ErrorType } from '../SwapButton/constants'
+import { type WalletClient } from 'viem'
 
 interface HandleSwapProps {
 	swapState: SwapState
 	swapDispatch: Dispatch<SwapAction>
+	walletClient: WalletClient
 }
 
-export const handleSwap = async ({ swapState, swapDispatch }: HandleSwapProps): Promise<void> => {
+export const handleSwap = async ({ swapState, swapDispatch, walletClient }: HandleSwapProps): Promise<void> => {
 	const { selectedRoute } = swapState
 
 	if (swapState.from.amount.length === 0) {
@@ -26,8 +28,8 @@ export const handleSwap = async ({ swapState, swapDispatch }: HandleSwapProps): 
 	swapDispatch({ type: 'SET_SWAP_STAGE', payload: SwapCardStage.progress })
 
 	try {
-		await executeConceroRoute(swapState, swapDispatch, selectedRoute)
-	} catch (error: Error) {
+		await executeConceroRoute({ swapState, swapDispatch, route: selectedRoute, walletClient })
+	} catch (error: any) {
 		handleTransactionError(error, swapDispatch, selectedRoute)
 	} finally {
 		swapDispatch({ type: 'SET_LOADING', payload: false })


### PR DESCRIPTION
Take wallet client out of execution hook. Move
wallet client to the top level so potential errors can be caught there. Update the error tracking
so that the error message is displayed in posthog.